### PR TITLE
Remove check for app install vs. content ad

### DIFF
--- a/ThirdPartyAdapters/mopub/CHANGELOG.md
+++ b/ThirdPartyAdapters/mopub/CHANGELOG.md
@@ -1,5 +1,8 @@
 # MoPub Adapter for Google Mobile Ads SDK for Android Changelog
 
+## 5.3.0.2
+- Remove the check that prevents ad requests for native content ad.
+
 ## 5.3.0.1
 - Initialize MoPub and reattempt ad requests manually in the adapters for use cases that do not do so in the app.
 

--- a/ThirdPartyAdapters/mopub/mopub/build.gradle
+++ b/ThirdPartyAdapters/mopub/mopub/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'maven-publish'
  */
 ext {
     // String property to store version name.
-    stringVersion = "5.3.0.1"
+    stringVersion = "5.3.0.2"
     // String property to store group id.
     stringGroupId = "com.google.ads.mediation"
 }
@@ -21,7 +21,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 27
-        versionCode 53010
+        versionCode 53020
         versionName stringVersion
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/ThirdPartyAdapters/mopub/mopub/src/main/java/com/mopub/mobileads/dfp/adapters/MoPubAdapter.java
+++ b/ThirdPartyAdapters/mopub/mopub/src/main/java/com/mopub/mobileads/dfp/adapters/MoPubAdapter.java
@@ -110,14 +110,6 @@ public class MoPubAdapter implements MediationNativeAdapter, MediationBannerAdap
         else
             privacyIconPlacement = NativeAdOptions.ADCHOICES_TOP_RIGHT;
 
-        if (!mediationAdRequest.isAppInstallAdRequested() && mediationAdRequest
-                .isContentAdRequested()) {
-            Log.d(TAG, "Currently, MoPub only serves native app install ads. Apps requesting "
-                    + "content ads alone will not receive ads from this adapter.");
-            listener.onAdFailedToLoad(MoPubAdapter.this, AdRequest.ERROR_CODE_INVALID_REQUEST);
-            return;
-        }
-
         if (mediationExtras != null) {
             int iconSizeExtra = mediationExtras.getInt(BundleBuilder.ARG_PRIVACY_ICON_SIZE_DP);
             if (iconSizeExtra < MINIMUM_MOPUB_PRIVACY_ICON_SIZE_DP) {
@@ -497,18 +489,15 @@ public class MoPubAdapter implements MediationNativeAdapter, MediationBannerAdap
                     break;
                 case NETWORK_TIMEOUT:
                     mMediationInterstitialListener.onAdFailedToLoad(MoPubAdapter.this,
-                            AdRequest
-                                    .ERROR_CODE_NETWORK_ERROR);
+                            AdRequest.ERROR_CODE_NETWORK_ERROR);
                     break;
                 case SERVER_ERROR:
                     mMediationInterstitialListener.onAdFailedToLoad(MoPubAdapter.this,
-                            AdRequest
-                                    .ERROR_CODE_INVALID_REQUEST);
+                            AdRequest.ERROR_CODE_INVALID_REQUEST);
                     break;
                 default:
                     mMediationInterstitialListener.onAdFailedToLoad(MoPubAdapter.this,
-                            AdRequest
-                                    .ERROR_CODE_INTERNAL_ERROR);
+                            AdRequest.ERROR_CODE_INTERNAL_ERROR);
                     break;
             }
         }

--- a/ThirdPartyAdapters/mopub/mopub/src/main/java/com/mopub/mobileads/dfp/adapters/MoPubNativeAppInstallAdMapper.java
+++ b/ThirdPartyAdapters/mopub/mopub/src/main/java/com/mopub/mobileads/dfp/adapters/MoPubNativeAppInstallAdMapper.java
@@ -136,19 +136,19 @@ public class MoPubNativeAppInstallAdMapper extends NativeAppInstallAdMapper {
 
             switch (privacyIconPlacement) {
                 case NativeAdOptions.ADCHOICES_TOP_LEFT:
-                    params.gravity = Gravity.TOP | Gravity.LEFT;
+                    params.gravity = Gravity.TOP | Gravity.START;
                     break;
                 case NativeAdOptions.ADCHOICES_BOTTOM_RIGHT:
-                    params.gravity = Gravity.BOTTOM | Gravity.RIGHT;
+                    params.gravity = Gravity.BOTTOM | Gravity.END;
                     break;
                 case NativeAdOptions.ADCHOICES_BOTTOM_LEFT:
-                    params.gravity = Gravity.BOTTOM | Gravity.LEFT;
+                    params.gravity = Gravity.BOTTOM | Gravity.START;
                     break;
                 case NativeAdOptions.ADCHOICES_TOP_RIGHT:
-                    params.gravity = Gravity.TOP | Gravity.RIGHT;
+                    params.gravity = Gravity.TOP | Gravity.END;
                     break;
                 default:
-                    params.gravity = Gravity.TOP | Gravity.RIGHT;
+                    params.gravity = Gravity.TOP | Gravity.END;
             }
             privacyInformationIconImageView.setLayoutParams(params);
             adView.requestLayout();


### PR DESCRIPTION
* Remove the check that distinguishes between AdMob's app install and content native ads (since Google started supporting the unified native ad).
* Use Gravity.START and END for better RTL support.
* Clean up syntax.